### PR TITLE
fix: allowing one UBI claim per day.

### DIFF
--- a/contracts/dao/schemes/FixedUBI.sol
+++ b/contracts/dao/schemes/FixedUBI.sol
@@ -3,39 +3,82 @@ pragma solidity 0.5.4;
 import "./UBI.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+/* @title Fixed amount-per-day UBI scheme allowing multiple claims
+ * across a longer period
+ */
 contract FixedUBI is AbstractUBI {
     using SafeMath for uint256;
 
-    uint256 fixedClaim;
+    mapping (address => uint) lastClaimed;
 
     constructor(
         Avatar _avatar,
         Identity _identity,
-        uint256 _amountToMint,
+        uint256 _initialReserve,
         uint _periodStart,
         uint _periodEnd,
-        uint256 _fixedClaim
+        uint256 _claimDistribution
     )
         public
-        AbstractUBI(_avatar, _identity, _amountToMint, _periodStart, _periodEnd)
+        AbstractUBI(_avatar, _identity, _initialReserve, _periodStart, _periodEnd)
     {
-        fixedClaim = _fixedClaim;
+        claimDistribution = _claimDistribution;
     }
 
-    function distributionFormula(uint256 /*amount*/, address /*user*/) internal returns(uint256) {
-        return fixedClaim;
+    /* @dev the claim calculation formula. Checks to see how many days
+     * the given address can claim for, with 7 being the maximum
+     * @param amount the amount per day one can claim
+     * @param user the claiming address
+     */
+    function distributionFormula(uint256 amount, address user) internal returns(uint256)
+    {
+        if(lastClaimed[user] < periodStart) {
+            lastClaimed[user] = periodStart.sub(1 days);
+        }
+
+        uint claimDays = now.sub(lastClaimed[user]) / 1 days; 
+        
+        claimDays = claimDays > 7 ? 7 : claimDays;
+
+        require(claimDays >= 1, "Has claimed within a day");
+        return amount.mul(claimDays);
     }
 
-    function start() public returns (bool) {
-        require(
-            (avatar.nativeToken().balanceOf(address(avatar)).add(amountToMint)) >=
-            (identity.getClaimerCount().mul(distributionFormula(0, address(0)))),
-            "Reserve not large enough"
-            );
+    /* @dev Sets the currentDay variable. Internal function
+     */
+    function setDay() internal {
+        uint dayDiff = now.sub(lastCalc);
+        lastCalc = now;
 
-        super.start();
+        currentDay = currentDay.add(dayDiff / 1 days);
+    }
 
-        claimDistribution = distributionFormula(0, address(0));
+    /* @dev Claiming function. Calculates how many days one can claim for and logs
+     * new claim and amount for the day.
+     * @returns A bool indicating if UBI was claimed
+     */
+    function claim()
+        public
+        requireActive
+        onlyClaimer
+        returns (bool)
+    {
+        uint256 newDistribution = distributionFormula(claimDistribution, msg.sender);
+        lastClaimed[msg.sender] = now;
+        setDay();
+
+        GoodDollar token = GoodDollar(address(avatar.nativeToken()));
+        token.transfer(msg.sender, newDistribution);
+
+        Day memory day = claimDay[currentDay];
+        
+        day.amountOfClaimers = day.amountOfClaimers.add(1);
+        day.claimAmount = day.claimAmount.add(newDistribution.sub(token.getFees(newDistribution)));
+        
+        claimDay[currentDay] = day;
+
+        emit UBIClaimed(msg.sender, newDistribution);
+        
         return true;
     }
 }


### PR DESCRIPTION
This PR closes #13 

- Fixed UBI scheme designed to last for longer periods. See ReserveRelayer for transferring funds after start

- Initial minting removed, as UBI schemes are expected to deploy on side chains, where minting shouldn't happen

- Amount to transfer from avatar can now be set, to allow continuous scheme deployments
