### PR TITLE
Fix totalClaimsPerUser stats

### DIFF
--- a/stakingModel/contracts/UBIScheme.sol
+++ b/stakingModel/contracts/UBIScheme.sol
@@ -295,7 +295,7 @@ contract UBIScheme is AbstractUBI {
 		day.amountOfClaimers = day.amountOfClaimers.add(1);
 		day.hasClaimed[_account] = true;
 		lastClaimed[_account] = now;
-		totalClaimsPerUser[_account].add(1);
+		totalClaimsPerUser[_account] = totalClaimsPerUser[_account].add(1);
 
 		// awards a new user or a fished user
 		if (_isFirstTime) {


### PR DESCRIPTION
# Description

I just tried to read the `totalClaimsPerUser` from the contract and it always returned `0`.
Then I found this issue on the contract code.